### PR TITLE
fix: remove duplicated "Engine" in generated engine name

### DIFF
--- a/src/AuroraBlueprints.Model/Comp/Engine.fs
+++ b/src/AuroraBlueprints.Model/Comp/Engine.fs
@@ -80,7 +80,7 @@ type Engine =
                 match this.MaintenanceClass with
                 | Military -> ""
                 | Commercial -> "Commercial "
-            sprintf "%.0fEP %s%s Engine" this.EnginePower cl this.EngineTech.Name
+            sprintf "%.0fEP %s%s" this.EnginePower cl this.EngineTech.Name
         )
     //#endregion
 


### PR DESCRIPTION
Closes #24